### PR TITLE
Report symlink sizes from FUSE mount for snapshot dir

### DIFF
--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -440,6 +440,8 @@ func (l *snapshotLink) Readlink(ctx context.Context, req *fuse.ReadlinkRequest) 
 func (l *snapshotLink) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Inode = l.inode
 	a.Mode = os.ModeSymlink | 0777
+	a.Size = uint64(len(l.target))
+	a.Blocks = 1 + a.Size/blockSize
 	a.Uid = l.root.uid
 	a.Gid = l.root.gid
 	a.Atime = l.snapshot.Time


### PR DESCRIPTION
Hoping you can merge this into your pull request restic#3668. The "latest" symlink in the restic fuse snapshots folders also lists a size of zero. This applies the same fix to that section of code as well.